### PR TITLE
나홀로 7주차 생존기

### DIFF
--- a/정재우/week7/Problem_1068_Gold5_DFS.java
+++ b/정재우/week7/Problem_1068_Gold5_DFS.java
@@ -1,0 +1,83 @@
+package week7;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Problem_1068_Gold5_DFS {
+    static List<Integer>[] graph;
+    static boolean[] visited;
+    static int N;
+    static int count;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        // 초기화
+        N = Integer.parseInt(br.readLine());
+        graph = new List[N];
+        for (int i = 0; i < N; i++) {
+            graph[i] = new ArrayList<>();
+        }
+        visited = new boolean[N];
+
+        // 노드 간의 관계 넣기
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int root = 0;
+        for (int i = 0; i < N; i++) {
+            int c = Integer.parseInt(st.nextToken());
+            if (c == -1) {
+                root = i;
+            } else { // c가 부모 노드이므로, 부모에 자식인 i를 추가
+                graph[c].add(i);
+            }
+        }
+
+        // 삭제할 노드 번호 입력
+        int deletedNode = Integer.parseInt(br.readLine());
+
+        // logic
+        count = 0;
+        deleteNode(deletedNode);
+        dfs(root);
+
+        // print
+        if (deletedNode == root) {
+            System.out.println(0);
+        } else {
+            System.out.println(count);
+        }
+    }
+
+    private static void dfs(int v) {
+        if (visited[v]) {
+            return;
+        }
+        visited[v] = true;
+        // 리프 노드인지 확인 -> graph[v].size()가 0인지 확인
+        if (graph[v].isEmpty()) {
+            count++;
+        }
+
+        // 다음 노드 탐색
+        for (Integer nextV : graph[v]) {
+            // 방문하지 않은 곳이거나, graph[nextV].get(0)이 -1이 아니어야 함
+            if (!visited[nextV]) {
+                dfs(nextV);
+            }
+        }
+    }
+
+    // i와, i에 딸려있는 graph[i]의 원소들을 모두 제거해야 함
+    // 이미 배열에 할당된 인덱스를 지울 수 없으므로, 임의로 graph[i].get(0)을 -1로 만들면서 모두 제거되었음을 시사해볼 예정
+    private static void deleteNode(int i) {
+        for (int j = 0; j < graph.length; j++) {
+            if (graph[j].contains(i)) {
+                graph[j].remove(Integer.valueOf(i));
+            }
+        }
+    }
+}

--- a/정재우/week7/Problem_1325_Silver1_DFS.java
+++ b/정재우/week7/Problem_1325_Silver1_DFS.java
@@ -1,0 +1,78 @@
+package week7;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Problem_1325_Silver1_DFS {
+    static List<Integer>[] graph;
+    static boolean[] visited;
+    static int N, E;
+    static int count;
+    static int[] result;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        E = Integer.parseInt(st.nextToken());
+
+        // init
+        graph = new List[N + 1];
+        for (int i = 0; i < N + 1; i++) {
+            graph[i] = new ArrayList<>();
+        }
+        visited = new boolean[N + 1];
+        result = new int[N + 1];
+
+        for (int i = 0; i < E; i++) {
+            StringTokenizer st1 = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st1.nextToken());
+            int b = Integer.parseInt(st1.nextToken());
+            graph[b].add(a);
+        }
+
+        // logic
+        for (int i = 1; i < N + 1; i++) {
+            count = 0;
+            dfs(i);
+            result[i] = count;
+            visited = new boolean[N + 1];
+        }
+
+        int max = getMaxFromArray(result);
+        for (int i = 0; i < result.length; i++) {
+            if (result[i] == max) {
+                System.out.print(i + " ");
+            }
+        }
+    }
+
+    private static void dfs(int v) {
+        if (visited[v]) {
+            return;
+        }
+        visited[v] = true;
+        count++;
+        for (Integer nextV : graph[v]) {
+            if (!visited[nextV]) {
+                dfs(nextV);
+            }
+        }
+    }
+
+    private static int getMaxFromArray(int[] array) {
+        int max = array[0];
+        for (int i = 0; i < array.length; i++) {
+            if (array[i] > max) {
+                max = array[i];
+            }
+        }
+
+        return max;
+    }
+}

--- a/정재우/week8/Problem_14502_Gold4_BFS.java
+++ b/정재우/week8/Problem_14502_Gold4_BFS.java
@@ -1,0 +1,115 @@
+package week8;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Problem_14502_Gold4_BFS {
+    static int[][] map;
+    static boolean[][] visited;
+    static int[] dx = {-1, 1, 0, 0};
+    static int[] dy = {0, 0, -1, 1};
+    static int H, W;
+    static int result = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st1 = new StringTokenizer(br.readLine());
+        H = Integer.parseInt(st1.nextToken());
+        W = Integer.parseInt(st1.nextToken());
+
+        map = new int[H][W];
+        visited = new boolean[H][W];
+
+        for (int i = 0; i < H; i++) {
+            StringTokenizer st2 = new StringTokenizer(br.readLine());
+            for (int j = 0; j < W; j++) {
+                map[i][j] = Integer.parseInt(st2.nextToken());
+            }
+        }
+
+        wallDfs(0);
+
+        System.out.println(result);
+    }
+
+    // 아무데나 벽 세워보기
+    private static void wallDfs(int count) {
+        // 벽이 3개 되면 바이러스 퍼뜨리고, 퍼진 지도를 기반으로 안전지역 구해서 최댓값과 비겨하기
+        if (count == 3) {
+            int safeAreaCount = proceedVirusAndCountSafeArea();
+            if (safeAreaCount > result) { // 안전 구역 최댓값 갱신
+                result = safeAreaCount;
+            }
+            return;
+        }
+
+        for (int i = 0; i < H; i++) {
+            for (int j = 0; j < W; j++) {
+                if (map[i][j] == 0) {
+                    map[i][j] = 1;
+                    wallDfs(count + 1);
+                    map[i][j] = 0;
+                }
+            }
+        }
+    }
+
+    private static int countSafeArea(int[][] map) {
+        int safeAreaCount = 0;
+        for (int i = 0; i < H; i++) {
+            for (int j = 0; j < W; j++) {
+                if (map[i][j] == 0) {
+                    safeAreaCount++;
+                }
+            }
+        }
+
+        return safeAreaCount;
+    }
+
+    private static int proceedVirusAndCountSafeArea() {
+        // 원본 훼손을 방지하기 위해 복사된 지도
+        int[][] copiedMap = new int[H][W];
+        for (int i = 0; i < H; i++) {
+            copiedMap[i] = map[i].clone();
+        }
+        visited = new boolean[H][W];
+
+        // 곧곧에 흩어져 있는 바이러스들을 조사해서 큐에 넣는 작업
+        Queue<int[]> queue = new LinkedList<>();
+        for (int i = 0; i < H; i++) {
+            for (int j = 0; j < W; j++) {
+                if (copiedMap[i][j] == 2) {
+                    queue.offer(new int[]{i, j});
+                    visited[i][j] = true;
+                }
+            }
+        }
+
+        while(!queue.isEmpty()) {
+            int[] poll = queue.poll();
+            int curY = poll[0];
+            int curX = poll[1];
+            for (int i = 0; i < 4; i++) {
+                int nextY = curY + dy[i];
+                int nextX = curX + dx[i];
+
+                if (nextX >= 0 && nextY >= 0 && nextX < W && nextY < H && !visited[nextY][nextX]) {
+                    // 빈 칸으로 바이러스가 침투
+                    if (copiedMap[nextY][nextX] == 0) {
+                        copiedMap[nextY][nextX] = 2;
+                        visited[nextY][nextX] = true;
+                        queue.offer(new int[]{nextY, nextX});
+                    }
+                }
+            }
+        }
+
+        return countSafeArea(copiedMap);
+    }
+}

--- a/정재우/week8/Problem_1697_Silver1_BFS.java
+++ b/정재우/week8/Problem_1697_Silver1_BFS.java
@@ -1,0 +1,59 @@
+package week8;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Problem_1697_Silver1_BFS {
+    static int[] map;
+    static int N, K;
+    static int count;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        map = new int[100001];
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+
+        // logic
+        bfs(N);
+
+        // print
+        if (N == K) {
+            System.out.println(0);
+        } else {
+            System.out.println(map[K]);
+        }
+    }
+
+    private static void bfs(int start) {
+        Queue<Integer> queue = new LinkedList<>();
+        queue.offer(start);
+
+        while(!queue.isEmpty()) {
+            Integer cur = queue.poll();
+            int[] next = new int[3];
+            next[0] = cur - 1;
+            next[1] = cur + 1;
+            next[2] = cur * 2;
+
+            for (int i = 0; i < next.length; i++) {
+                if (next[i] >= 0 && next[i] <= 100000) {
+                    if (map[next[i]] != 0 && map[next[i]] <= map[cur] + 1) {
+                        continue;
+                    }
+                    map[next[i]] = map[cur] + 1;
+                    if (next[i] == K) {
+                        break;
+                    }
+                    queue.offer(next[i]);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
##  🏆 문제별 후기

<details>
<summary>1️⃣ 1325 / 효율적인 해킹 / 🥈 Silver 1 / DFS</summary>

## 문제 설명

- 이어져 있는 컴퓨터들을 그래프로 삼아, 몇 번 노드에서 DFS를 시작했을 때 가장 많은 컴퓨터를 해킹할 수 있는지 찾는 문제이다.

## 풀이
![image](https://github.com/user-attachments/assets/a43eddba-0f47-479d-9b36-86e498a6de86)
- 기본적인 그래프 + DFS 문제의 형식을 따라가고 있다. 각 컴퓨터들을 노드로, 컴퓨터 간의 신뢰 관계를 엣지로 생각하면 된다.
- 다만 한 가지 헷갈릴 뻔했던 것은 노드 간의 관계가 **단방향 관계**라는 것이다. 처음 그래프에 정점을 추가할 때 조심해야 한다.
    
    ```java
    for (int i = 0; i < E; i++) {
    	  StringTokenizer st1 = new StringTokenizer(br.readLine());
        int a = Integer.parseInt(st1.nextToken());
        int b = Integer.parseInt(st1.nextToken());
        graph[b].add(a);
        // graph[a].add(b); 이걸 빼야 단방향 관계가 됨!
    }
    ```

## 후기

- 채점하는데 무슨 1분 30초씩 걸려서 심장이 너무 쫄렸다.
- 시간 초과나 오답 나올 줄 알았는데 의외로 1트에 성공해서 매우 다행이라 생각했다.
- 뭔가 메모리를 너무 많이 써서 더 효율적인 코드가 있을 것 같긴 한데, 성능 자체가 이 문제의 핵심은 아니니 넘어가기로 했다.
</details>

<details>
<summary>2️⃣ 1068 / 트리 / 🥇 Gold 5 / DFS</summary>
## 문제 설명

- 트리에서 특정 노드와 그 자식들을 제거했을 때, 남은 리프 노드의 개수가 얼마인지 구하는 문제이다.

## 풀이
![image](https://github.com/user-attachments/assets/4f4090b6-d28f-4b52-a224-f9500cb8c402)
- 특정 노드와 그 자식들을 모두 삭제 처리하는 로직이 핵심이었다.
    
    처음에 이 로직을 못 짜서 77%에서 2번 실패했다.
    
- 일단 삭제 대상인 노드 `i` 를 자식으로 가지는 부모 노드가 있다면, `i` 를 모두 없애도록 했다.
    
    → 즉, 삭제되는 그래프와 남은 그래프 간의 연결을 끊었다.
    

- 하지만 루트 노드를 삭제하려는 경우, 연결이 끊어지는 게 아니라 그냥 모든 그래프가 사라진다.
    
    → 따라서 루트 노드를 삭제하면 전체 노드의 개수가 0이 된다. → 리프 노드의 개수도 0이다.
    

## 후기

- 이제 DFS는 진짜 익숙해진 것 같다. 좌표평면이 나오든 그래프가 나오든 골드 5 정도까진 앵간하면 다 풀 것 같다.
- 이제 DFS를 어느정도 완성했으니까 BFS를 많이 풀어봐야 할 것 같다.

</details>

## 😎 전체 후기

- 월요일 땡 시작하자마자 몇 문제 풀었으면 좋았을텐데, 미루다보니까 갑자기 2/14 금요일부터 연합 동아리 지원 + MT가 겹쳐서 한 문제도 못 풀었다.
- 이제와서 푼다고 벌금이 사라지는 건 아니지만 그래도 그냥 넘어가기 찝찝하니까 2문제는 7주차로 올립니당
- 골드 문제는 풀 때마다 짜릿하다